### PR TITLE
Modify long description content type in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ author_email = pypi@xlab.si
 license_file = LICENSE
 description = Python library for different object storages that have common methods.
 long_description = file: README.md
-long_description_content_type="text/markdown",
+long_description_content_type= text/markdown
 keywords =
     library
     object store


### PR DESCRIPTION
Remove commma and quotation marks which caused a failure when uploading the package to PyPI.